### PR TITLE
[API-3174] Make chain schema Initia specific

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -33,26 +33,22 @@
                 "polygon"
             ]
         },
+        "should_index": {
+            "type": "boolean",
+            "description": "If Skip should automatically start indexing this chain via the provided GRPC API once it is on the main branch.",
+            "default": false
+        },
         "apis": {
             "type": "object",
             "properties": {
                 "rpc": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/endpoint"
-                    }
+                    "$ref": "#/$defs/endpoint"
                 },
                 "rest": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/endpoint"
-                    }
+                    "$ref": "#/$defs/endpoint"
                 },
                 "grpc": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/grpc_endpoint"
-                    }
+                    "$ref": "#/$defs/grpc_endpoint"
                 }
             },
             "additionalProperties": false

--- a/chains/initiation-1/chain.json
+++ b/chains/initiation-1/chain.json
@@ -3,7 +3,7 @@
     "chain_id": "initiation-1",
     "is_testnet": true,
     "chain_name": "initia",
-    "should_index": true,
+    "chain_type": "initia",
     "apis": {
         "tendermint_rpc_endpoint": {
             "address": "https://rpc-skip.initiation-1.initia.xyz",

--- a/chains/initiation-1/chain.json
+++ b/chains/initiation-1/chain.json
@@ -1,21 +1,21 @@
 {
-    "$schema": "../../chain.schema.json",
-    "chain_id": "initia-1",
+    "$schema": "../../initia.chain.schema.json",
+    "chain_id": "initiation-1",
     "is_testnet": true,
     "chain_name": "initia",
     "should_index": true,
     "apis": {
-        "rpc": {
+        "tendermint_rpc_endpoint": {
             "address": "https://rpc-skip.initiation-1.initia.xyz",
             "provider": "Initia Labs",
             "backoff_delay": 1000
         },
-        "rest": {
+        "lcd_rest_endpoint": {
             "address": "https://lcd-skip.initiation-1.initia.xyz",
             "provider": "Initia Labs",
             "backoff_delay": 1000
         },
-        "grpc": {
+        "cosmos_sdk_grpc_endpoint": {
             "address": "35.240.231.235:9090",
             "provider": "Initia Labs",
             "backoff_delay": 1000,

--- a/chains/initiation-1/chain.json
+++ b/chains/initiation-1/chain.json
@@ -3,28 +3,23 @@
     "chain_id": "initia-1",
     "is_testnet": true,
     "chain_name": "initia",
+    "should_index": true,
     "apis": {
-        "rpc": [
-            {
-                "address": "https://rpc-skip.initiation-1.initia.xyz",
-                "provider": "Initia Labs",
-                "backoff_delay": 1000
-            }
-        ],
-        "rest": [
-            {
-                "address": "https://lcd-skip.initiation-1.initia.xyz",
-                "provider": "Initia Labs",
-                "backoff_delay": 1000
-            }
-        ],
-        "grpc": [
-            {
-                "address": "35.240.231.235:9090",
-                "provider": "Initia Labs",
-                "backoff_delay": 1000,
-                "tls": false
-            }
-        ]
+        "rpc": {
+            "address": "https://rpc-skip.initiation-1.initia.xyz",
+            "provider": "Initia Labs",
+            "backoff_delay": 1000
+        },
+        "rest": {
+            "address": "https://lcd-skip.initiation-1.initia.xyz",
+            "provider": "Initia Labs",
+            "backoff_delay": 1000
+        },
+        "grpc": {
+            "address": "35.240.231.235:9090",
+            "provider": "Initia Labs",
+            "backoff_delay": 1000,
+            "tls": false
+        }
     }
 }

--- a/chains/minimove-1/chain.json
+++ b/chains/minimove-1/chain.json
@@ -3,28 +3,23 @@
     "chain_id": "minimove-1",
     "is_testnet": true,
     "chain_name": "minimove",
+    "should_index": true,
     "apis": {
-        "rpc": [
-            {
-                "address": "https://rpc-skip.minimove-1.initia.xyz",
-                "provider": "Initia Labs",
-                "backoff_delay": 1000
-            }
-        ],
-        "rest": [
-            {
-                "address": "https://lcd-skip.minimove-1.initia.xyz",
-                "provider": "Initia Labs",
-                "backoff_delay": 1000
-            }
-        ],
-        "grpc": [
-            {
-                "address": "34.124.136.240:9090",
-                "provider": "Initia Labs",
-                "backoff_delay": 1000,
-                "tls": false
-            }
-        ]
+        "rpc": {
+            "address": "https://rpc-skip.minimove-1.initia.xyz",
+            "provider": "Initia Labs",
+            "backoff_delay": 1000
+        },
+        "rest": {
+            "address": "https://lcd-skip.minimove-1.initia.xyz",
+            "provider": "Initia Labs",
+            "backoff_delay": 1000
+        },
+        "grpc": {
+            "address": "34.124.136.240:9090",
+            "provider": "Initia Labs",
+            "backoff_delay": 1000,
+            "tls": false
+        }
     }
 }

--- a/chains/minimove-1/chain.json
+++ b/chains/minimove-1/chain.json
@@ -1,21 +1,16 @@
 {
-    "$schema": "../../chain.schema.json",
+    "$schema": "../../initia.chain.schema.json",
     "chain_id": "minimove-1",
     "is_testnet": true,
     "chain_name": "minimove",
     "should_index": true,
     "apis": {
-        "rpc": {
+        "tendermint_rpc_endpoint": {
             "address": "https://rpc-skip.minimove-1.initia.xyz",
             "provider": "Initia Labs",
             "backoff_delay": 1000
         },
-        "rest": {
-            "address": "https://lcd-skip.minimove-1.initia.xyz",
-            "provider": "Initia Labs",
-            "backoff_delay": 1000
-        },
-        "grpc": {
+        "cosmos_sdk_grpc_endpoint": {
             "address": "34.124.136.240:9090",
             "provider": "Initia Labs",
             "backoff_delay": 1000,

--- a/chains/minimove-1/chain.json
+++ b/chains/minimove-1/chain.json
@@ -3,7 +3,7 @@
     "chain_id": "minimove-1",
     "is_testnet": true,
     "chain_name": "minimove",
-    "should_index": true,
+    "chain_type": "initia",
     "apis": {
         "tendermint_rpc_endpoint": {
             "address": "https://rpc-skip.minimove-1.initia.xyz",

--- a/chains/miniwasm-1/chain.json
+++ b/chains/miniwasm-1/chain.json
@@ -3,7 +3,7 @@
     "chain_id": "miniwasm-1",
     "is_testnet": true,
     "chain_name": "miniwasm",
-    "should_index": true,
+    "chain_type": "initia",
     "apis": {
         "tendermint_rpc_endpoint": {
             "address": "https://rpc-skip.miniwasm-1.initia.xyz",

--- a/chains/miniwasm-1/chain.json
+++ b/chains/miniwasm-1/chain.json
@@ -3,28 +3,23 @@
     "chain_id": "miniwasm-1",
     "is_testnet": true,
     "chain_name": "miniwasm",
+    "should_index": true,
     "apis": {
-        "rpc": [
-            {
-                "address": "https://rpc-skip.miniwasm-1.initia.xyz",
-                "provider": "Initia Labs",
-                "backoff_delay": 1000
-            }
-        ],
-        "rest": [
-            {
-                "address": "https://lcd-skip.miniwasm-1.initia.xyz",
-                "provider": "Initia Labs",
-                "backoff_delay": 1000
-            }
-        ],
-        "grpc": [
-            {
-                "address": "34.124.147.66:9090",
-                "provider": "Initia Labs",
-                "backoff_delay": 1000,
-                "tls": false
-            }
-        ]
+        "rpc": {
+            "address": "https://rpc-skip.miniwasm-1.initia.xyz",
+            "provider": "Initia Labs",
+            "backoff_delay": 1000
+        },
+        "rest": {
+            "address": "https://lcd-skip.miniwasm-1.initia.xyz",
+            "provider": "Initia Labs",
+            "backoff_delay": 1000
+        },
+        "grpc": {
+            "address": "34.124.147.66:9090",
+            "provider": "Initia Labs",
+            "backoff_delay": 1000,
+            "tls": false
+        }
     }
 }

--- a/chains/miniwasm-1/chain.json
+++ b/chains/miniwasm-1/chain.json
@@ -1,21 +1,16 @@
 {
-    "$schema": "../../chain.schema.json",
+    "$schema": "../../initia.chain.schema.json",
     "chain_id": "miniwasm-1",
     "is_testnet": true,
     "chain_name": "miniwasm",
     "should_index": true,
     "apis": {
-        "rpc": {
+        "tendermint_rpc_endpoint": {
             "address": "https://rpc-skip.miniwasm-1.initia.xyz",
             "provider": "Initia Labs",
             "backoff_delay": 1000
         },
-        "rest": {
-            "address": "https://lcd-skip.miniwasm-1.initia.xyz",
-            "provider": "Initia Labs",
-            "backoff_delay": 1000
-        },
-        "grpc": {
+        "cosmos_sdk_grpc_endpoint": {
             "address": "34.124.147.66:9090",
             "provider": "Initia Labs",
             "backoff_delay": 1000,

--- a/initia.chain.schema.json
+++ b/initia.chain.schema.json
@@ -18,7 +18,7 @@
             "minLength": 1,
             "pattern": "[a-z0-9]-+",
             "examples": [
-                "cosmoshub-4"
+                "initiation-1"
             ]
         },
         "is_testnet": {
@@ -30,24 +30,24 @@
             "minLength": 1,
             "pattern": "[a-z0-9]+",
             "examples": [
-                "polygon"
+                "minimove"
             ]
-        },
-        "should_index": {
-            "type": "boolean",
-            "description": "If Skip should automatically start indexing this chain via the provided GRPC API once it is on the main branch.",
-            "default": false
         },
         "apis": {
             "type": "object",
             "properties": {
-                "rpc": {
+                "required": [
+                    "cosmos_sdk_grpc_endpoint",
+                    "tendermint_rpc_endpoint"
+                ],
+                "lcd_rest_endpoint": {
+                    "$ref": "#/$defs/endpoint",
+                    "description": "Only required for initia-1."
+                },
+                "tendermint_rpc_endpoint": {
                     "$ref": "#/$defs/endpoint"
                 },
-                "rest": {
-                    "$ref": "#/$defs/endpoint"
-                },
-                "grpc": {
+                "cosmos_sdk_grpc_endpoint": {
                     "$ref": "#/$defs/grpc_endpoint"
                 }
             },

--- a/initia.chain.schema.json
+++ b/initia.chain.schema.json
@@ -5,13 +5,14 @@
     "required": [
         "chain_id",
         "is_testnet",
-        "chain_name"
+        "chain_name",
+        "chain_type"
     ],
     "properties": {
         "$schema": {
             "type": "string",
             "minLength": 1,
-            "pattern": "^(\\.\\./)+chain\\.schema\\.json$"
+            "pattern": "^(\\.\\./)+initia.chain\\.schema\\.json$"
         },
         "chain_id": {
             "type": "string",
@@ -32,6 +33,9 @@
             "examples": [
                 "minimove"
             ]
+        },
+        "chain_type": {
+            "const": "initia"
         },
         "apis": {
             "type": "object",


### PR DESCRIPTION
This makes what was the chain schema now specific to Initia. It was going to be too difficult to try and get every chain to conform to a single schema, so instead each chain/ecosystem type will have its own schema. That way we can be more specific with fields, like we are now doing with initia's endpoint types.