### PR TITLE
[API-3746] Assetlist schema required field updates

### DIFF
--- a/assetlist.schema.json
+++ b/assetlist.schema.json
@@ -57,17 +57,20 @@
                     },
                     "evm_native_asset_name": {
                         "type": "string",
-                        "description": "Only required for native assets. A unique identifier for this asset. A native asset's ID should have the suffix -native. e.g. ethereum-native for ethereum. Either erc20_contract_address, id, or denom should be defined."
+                        "minLength": 8,
+                        "pattern": "[a-zA-Z]-native",
+                        "description": "Required for evm_native asset types. A unique identifier for this asset. A native asset's ID should have the suffix -native. e.g. ethereum-native for ethereum."
                     },
                     "denom": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "[OPTIONAL] The denomination of the token. Either erc20_contract_address, id, or denom should be defined." },
+                        "description": "Required for cosmos asset types. The denomination of the token." 
+                    },
                     "erc20_contract_address": {
                         "type": "string",
                         "minLength": 1,
                         "pattern": "0x[a-zA-Z0-9]*$",
-                        "description": "[OPTIONAL] The ERC20 contract address of the asset. Either erc20_contract_address, id, or denom should be defined."
+                        "description": "Required for erc20 asset types. The ERC20 contract address of the asset."
                     },
                     "name": {
                         "type": "string",

--- a/assetlist.schema.json
+++ b/assetlist.schema.json
@@ -26,88 +26,96 @@
             "items": {
                 "type": "object",
                 "description": "An asset on this chain.",
-                "allOf": [
+                "additionalProperties": false,
+                "required": [
+                    "asset_type"
+                ],
+                "anyOf": [
                     {
-                        "oneOf": [
-                            {
-                                "required": ["denom"]
-                            },
-                            {
-                                "required": ["erc20_contract_address"]
-                            },
-                            {
-                                "required": ["id"]
-                            }
-                        ]
+                      "properties": {
+                        "asset_type": { "const": "cosmos" }
+                      },
+                      "required": ["denom"]
                     },
                     {
-                        "type": "object",
-                        "additionalProperties": false,
-                        "properties": {
-                            "id": {
-                                "type": "string",
-                                "description": "Only required for native assets. A unique identifier for this asset. A native asset's ID should have the suffix -native. e.g. ethereum-native for ethereum. Either erc20_contract_address, id, or denom should be defined."
-                            },
-                            "name": {
-                                "type": "string",
-                                "minLength": 1,
-                                "description": "[OPTIONAL] The name of the asset."
-                            },
-                            "decimals": {
-                                "type": "integer",
-                                "description": "[OPTIONAL] The decimals value of the asset."
-                            },
-                            "erc20_contract_address": {
-                                "type": "string",
-                                "minLength": 1,
-                                "pattern": "0x[a-zA-Z0-9]*$",
-                                "description": "[OPTIONAL] The ERC20 contract address of the asset. Either erc20_contract_address, id, or denom should be defined."
-                            },
-                            "denom": {
-                                "type": "string",
-                                "minLength": 1,
-                                "description": "[OPTIONAL] The denomination of the token. Either erc20_contract_address, id, or denom should be defined."
-                            },
-                            "symbol": {
-                                "type": "string",
-                                "minLength": 1,
-                                "description": "[OPTIONAL] The symbol of the asset."
-                            },
-                            "logo_uri": {
-                                "type": "string",
-                                "format": "uri-reference",
-                                "minLength": 1,
-                                "description": "[OPTIONAL] The logo URI of the asset."
-                            },
-                            "coingecko_id": {
-                                "type": "string",
-                                "minLength": 1,
-                                "description": "[OPTIONAL] The coingecko ID of the asset."
-                            },
-                            "axelar_symbol": {
-                                "type": "string",
-                                "description": "[OPTIONAL] The axelar symbol of the asset."
-                            },
-                            "axelar_denom": {
-                                "type": "string",
-                                "description": "[OPTIONAL] The axelar denom of the asset."
-                            },
-                            "axelar_name": {
-                                "type": "string",
-                                "description": "[OPTIONAL] The axelar name of the asset."
-                            },
-                            "go_fast_enabled": {
-                                "type": "boolean",
-                                "default": false,
-                                "description": "[OPTIONAL] If this asset is fast transferable via Skip Go Fast."
-                            },
-                            "recommended_symbol": {
-                                "type": "string",
-                                "description": "[OPTIONAL] The recommended symbol for this asset."
-                            }
-                        }
+                      "properties": {
+                        "asset_type": { "const": "erc20" }
+                      },
+                      "required": ["erc20_contract_address"]
+                    },
+                    {
+                      "properties": {
+                        "asset_type": { "const": "evm_native" }
+                      },
+                      "required": ["evm_native_asset_name"]
                     }
-                ]
+                ],
+                "properties": {
+                    "asset_type": {
+                        "type": "string",
+                        "enum": ["cosmos", "evm_native", "erc20"] 
+                    },
+                    "evm_native_asset_name": {
+                        "type": "string",
+                        "description": "Only required for native assets. A unique identifier for this asset. A native asset's ID should have the suffix -native. e.g. ethereum-native for ethereum. Either erc20_contract_address, id, or denom should be defined."
+                    },
+                    "denom": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "[OPTIONAL] The denomination of the token. Either erc20_contract_address, id, or denom should be defined." },
+                    "erc20_contract_address": {
+                        "type": "string",
+                        "minLength": 1,
+                        "pattern": "0x[a-zA-Z0-9]*$",
+                        "description": "[OPTIONAL] The ERC20 contract address of the asset. Either erc20_contract_address, id, or denom should be defined."
+                    },
+                    "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "[OPTIONAL] The name of the asset."
+                    },
+                    "decimals": {
+                        "type": "integer",
+                        "description": "[OPTIONAL] The decimals value of the asset."
+                    },
+                    "symbol": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "[OPTIONAL] The symbol of the asset."
+                    },
+                    "logo_uri": {
+                        "type": "string",
+                        "format": "uri-reference",
+                        "minLength": 1,
+                        "description": "[OPTIONAL] The logo URI of the asset."
+                    },
+                    "coingecko_id": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "[OPTIONAL] The coingecko ID of the asset."
+                    },
+                    "axelar_symbol": {
+                        "type": "string",
+                        "description": "[OPTIONAL] The axelar symbol of the asset."
+                    },
+                    "axelar_denom": {
+                        "type": "string",
+                        "description": "[OPTIONAL] The axelar denom of the asset."
+                    },
+                    "axelar_name": {
+                        "type": "string",
+                        "description": "[OPTIONAL] The axelar name of the asset."
+                    },
+                    "go_fast_enabled": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "[OPTIONAL] If this asset is fast transferable via Skip Go Fast."
+                    },
+                    "recommended_symbol": {
+                        "type": "string",
+                        "description": "[OPTIONAL] The recommended symbol for this asset."
+                    }
+                }
             }
         }
     }

--- a/assetlist.schema.json
+++ b/assetlist.schema.json
@@ -26,72 +26,88 @@
             "items": {
                 "type": "object",
                 "description": "An asset on this chain.",
-                "required": [
-                    "name",
-                    "decimals",
-                    "symbol",
-                    "logo_uri",
-                    "coingecko_id"
-                ],
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "description": "Only required for native assets. A unique identifier for this asset. A native asset's ID should have the suffix -native. e.g. ethereum-native for ethereum."
+                "allOf": [
+                    {
+                        "oneOf": [
+                            {
+                                "required": ["denom"]
+                            },
+                            {
+                                "required": ["erc20_contract_address"]
+                            },
+                            {
+                                "required": ["id"]
+                            }
+                        ]
                     },
-                    "name": {
-                        "type": "string",
-                        "minLength": 1,
-                        "description": "The name of the asset."
-                    },
-                    "decimals": {
-                        "type": "integer",
-                        "description": "The decimals value of the asset."
-                    },
-                    "erc20_contract_address": {
-                        "type": "string",
-                        "minLength": 1,
-                        "pattern": "0x[a-zA-Z0-9]*$",
-                        "description": "[OPTIONAL] The ERC20 contract address of the asset."
-                    },
-                    "denom": {
-                        "type": "string",
-                        "minLength": 1,
-                        "description": "[OPTIONAL] The denomination of the token. Either erc20_contract_address or denom should be defined."
-                    },
-                    "symbol": {
-                        "type": "string",
-                        "minLength": 1,
-                        "description": "The symbol of the asset."
-                    },
-                    "logo_uri": {
-                        "type": "string",
-                        "format": "uri-reference",
-                        "minLength": 1,
-                        "description": "The logo URI of the asset."
-                    },
-                    "coingecko_id": {
-                        "type": "string",
-                        "minLength": 1,
-                        "description": "The coingecko ID of the asset."
-                    },
-                    "axelar_symbol": {
-                        "type": "string",
-                        "description": "[OPTIONAL] The axelar symbol of the asset."
-                    },
-                    "axelar_denom": {
-                        "type": "string",
-                        "description": "[OPTIONAL] The axelar denom of the asset."
-                    },
-                    "axelar_name": {
-                        "type": "string",
-                        "description": "[OPTIONAL] The axelar name of the asset."
-                    },
-                    "go_fast_enabled": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "[OPTIONAL] If this asset is fast transferable via Skip Go Fast."
+                    {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "Only required for native assets. A unique identifier for this asset. A native asset's ID should have the suffix -native. e.g. ethereum-native for ethereum. Either erc20_contract_address, id, or denom should be defined."
+                            },
+                            "name": {
+                                "type": "string",
+                                "minLength": 1,
+                                "description": "[OPTIONAL] The name of the asset."
+                            },
+                            "decimals": {
+                                "type": "integer",
+                                "description": "[OPTIONAL] The decimals value of the asset."
+                            },
+                            "erc20_contract_address": {
+                                "type": "string",
+                                "minLength": 1,
+                                "pattern": "0x[a-zA-Z0-9]*$",
+                                "description": "[OPTIONAL] The ERC20 contract address of the asset. Either erc20_contract_address, id, or denom should be defined."
+                            },
+                            "denom": {
+                                "type": "string",
+                                "minLength": 1,
+                                "description": "[OPTIONAL] The denomination of the token. Either erc20_contract_address, id, or denom should be defined."
+                            },
+                            "symbol": {
+                                "type": "string",
+                                "minLength": 1,
+                                "description": "[OPTIONAL] The symbol of the asset."
+                            },
+                            "logo_uri": {
+                                "type": "string",
+                                "format": "uri-reference",
+                                "minLength": 1,
+                                "description": "[OPTIONAL] The logo URI of the asset."
+                            },
+                            "coingecko_id": {
+                                "type": "string",
+                                "minLength": 1,
+                                "description": "[OPTIONAL] The coingecko ID of the asset."
+                            },
+                            "axelar_symbol": {
+                                "type": "string",
+                                "description": "[OPTIONAL] The axelar symbol of the asset."
+                            },
+                            "axelar_denom": {
+                                "type": "string",
+                                "description": "[OPTIONAL] The axelar denom of the asset."
+                            },
+                            "axelar_name": {
+                                "type": "string",
+                                "description": "[OPTIONAL] The axelar name of the asset."
+                            },
+                            "go_fast_enabled": {
+                                "type": "boolean",
+                                "default": false,
+                                "description": "[OPTIONAL] If this asset is fast transferable via Skip Go Fast."
+                            },
+                            "recommended_symbol": {
+                                "type": "string",
+                                "description": "[OPTIONAL] The recommended symbol for this asset."
+                            }
+                        }
                     }
-                }
+                ]
             }
         }
     }

--- a/chains/1/assetlist.json
+++ b/chains/1/assetlist.json
@@ -3,7 +3,8 @@
     "chain_name": "ethereum",
     "assets": [
         {
-            "id": "ethereum-native",
+            "asset_type": "evm_native",
+            "evm_native_asset_name": "ethereum-native",
             "symbol": "ETH",
             "name": "Ethereum",
             "axelar_symbol": "WETH",
@@ -14,6 +15,7 @@
             "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-blue.svg"
         },
         {
+            "asset_type": "erc20",
             "name": "USDC",
             "decimals": 6,
             "erc20_contract_address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",

--- a/chains/1/assetlist.json
+++ b/chains/1/assetlist.json
@@ -19,7 +19,6 @@
             "name": "USDC",
             "decimals": 6,
             "erc20_contract_address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-            "denom": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
             "symbol": "USDC",
             "logo_uri": "https://raw.githubusercontent.com/axelarnetwork/axelar-configs/main/images/tokens/usdc.svg",
             "coingecko_id": "usd-coin",

--- a/chains/10/assetlist.json
+++ b/chains/10/assetlist.json
@@ -3,7 +3,8 @@
     "chain_name": "optimism",
     "assets": [
         {
-            "id": "optimism-native",
+            "asset_type": "evm_native",
+            "evm_native_asset_name": "optimism-native",
             "symbol": "ETH",
             "name": "ETH",
             "decimals": 18,
@@ -11,6 +12,7 @@
             "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-blue.svg"
         },
         {
+            "asset_type": "erc20",
             "name": "Optimism USDC",
             "decimals": 6,
             "erc20_contract_address": "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
@@ -21,6 +23,7 @@
             "go_fast_enabled": true
         },
         {
+            "asset_type": "erc20",
             "name": "Bridged USDC",
             "decimals": 6,
             "erc20_contract_address": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
@@ -30,6 +33,7 @@
             "coingecko_id": "bridged-usdc-optimism"
         },
         {
+            "asset_type": "erc20",
             "name": "Tether USD",
             "decimals": 6,
             "erc20_contract_address": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",

--- a/chains/10/assetlist.json
+++ b/chains/10/assetlist.json
@@ -16,7 +16,6 @@
             "name": "Optimism USDC",
             "decimals": 6,
             "erc20_contract_address": "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
-            "denom": "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
             "symbol": "USDC",
             "logo_uri": "https://raw.githubusercontent.com/axelarnetwork/axelar-configs/main/images/tokens/usdc.svg",
             "coingecko_id": "usd-coin",
@@ -27,7 +26,6 @@
             "name": "Bridged USDC",
             "decimals": 6,
             "erc20_contract_address": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
-            "denom": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
             "symbol": "USDC.e",
             "logo_uri": "https://assets-cdn.trustwallet.com/blockchains/optimism/assets/0x7F5c764cBc14f9669B88837ca1490cCa17c31607/logo.png",
             "coingecko_id": "bridged-usdc-optimism"
@@ -37,7 +35,6 @@
             "name": "Tether USD",
             "decimals": 6,
             "erc20_contract_address": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
-            "denom": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
             "symbol": "USDT",
             "logo_uri": "https://assets-cdn.trustwallet.com/blockchains/optimism/assets/0x94b008aA00579c1307B0EF2c499aD98a8ce58e58/logo.png",
             "coingecko_id": "tether"

--- a/chains/11155111/assetlist.json
+++ b/chains/11155111/assetlist.json
@@ -7,7 +7,6 @@
             "name": "Sepolia USDC",
             "decimals": 6,
             "erc20_contract_address": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
-            "denom": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
             "symbol": "USDC",
             "logo_uri": "https://raw.githubusercontent.com/axelarnetwork/axelar-configs/main/images/tokens/usdc.svg",
             "coingecko_id": "usd-coin"

--- a/chains/11155111/assetlist.json
+++ b/chains/11155111/assetlist.json
@@ -3,6 +3,7 @@
     "chain_name": "ethereum-sepolia-tesetnet",
     "assets": [
         {
+            "asset_type": "erc20",
             "name": "Sepolia USDC",
             "decimals": 6,
             "erc20_contract_address": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",

--- a/chains/11155420/assetlist.json
+++ b/chains/11155420/assetlist.json
@@ -3,6 +3,7 @@
     "chain_name": "optimism-sepolia-testnet",
     "assets": [
         {
+            "asset_type": "erc20",
             "name": "Optimism USDC",
             "decimals": 6,
             "erc20_contract_address": "0x5fd84259d66Cd46123540766Be93DFE6D43130D7",

--- a/chains/11155420/assetlist.json
+++ b/chains/11155420/assetlist.json
@@ -7,7 +7,6 @@
             "name": "Optimism USDC",
             "decimals": 6,
             "erc20_contract_address": "0x5fd84259d66Cd46123540766Be93DFE6D43130D7",
-            "denom": "0x5fd84259d66Cd46123540766Be93DFE6D43130D7",
             "symbol": "USDC",
             "logo_uri": "https://raw.githubusercontent.com/axelarnetwork/axelar-configs/main/images/tokens/usdc.svg",
             "coingecko_id": "usd-coin"

--- a/chains/1284/assetlist.json
+++ b/chains/1284/assetlist.json
@@ -3,7 +3,8 @@
     "chain_name": "moonbeam",
     "assets": [
         {
-            "id": "moonbeam-native",
+            "asset_type": "evm_native",
+            "evm_native_asset_name": "moonbeam-native",
             "symbol": "GLMR",
             "name": "Moonbeam",
             "axelar_symbol": "WGLMR",

--- a/chains/1329/assetlist.json
+++ b/chains/1329/assetlist.json
@@ -3,7 +3,8 @@
   "chain_name": "sei",
   "assets": [
     {
-      "id": "sei-native",
+      "asset_type": "evm_native",
+      "evm_native_asset_name": "sei-native",
       "symbol": "SEI",
       "name": "Sei",
       "decimals": 18,
@@ -11,6 +12,7 @@
       "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sei/images/sei.svg"
     },
     {
+      "asset_type": "erc20",
       "name": "Wrapped Ether",
       "decimals": 18,
       "erc20_contract_address": "0x160345fC359604fC6e70E3c5fAcbdE5F7A9342d8",
@@ -20,6 +22,7 @@
       "coingecko_id": "ethereum"
     },
     {
+      "asset_type": "erc20",
       "name": "USDC",
       "decimals": 6,
       "erc20_contract_address": "0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1",
@@ -29,6 +32,7 @@
       "coingecko_id": "usd-coin"
     },
     {
+      "asset_type": "erc20",
       "name": "Tether USD",
       "decimals": 6,
       "erc20_contract_address": "0xB75D0B03c06A926e488e2659DF1A861F860bD3d1",

--- a/chains/1329/assetlist.json
+++ b/chains/1329/assetlist.json
@@ -16,7 +16,6 @@
       "name": "Wrapped Ether",
       "decimals": 18,
       "erc20_contract_address": "0x160345fC359604fC6e70E3c5fAcbdE5F7A9342d8",
-      "denom": "0x160345fC359604fC6e70E3c5fAcbdE5F7A9342d8",
       "symbol": "WETH",
       "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-blue.svg",
       "coingecko_id": "ethereum"
@@ -26,7 +25,6 @@
       "name": "USDC",
       "decimals": 6,
       "erc20_contract_address": "0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1",
-      "denom": "0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1",
       "symbol": "USDC",
       "logo_uri": "https://raw.githubusercontent.com/axelarnetwork/axelar-configs/main/images/tokens/usdc.svg",
       "coingecko_id": "usd-coin"
@@ -36,7 +34,6 @@
       "name": "Tether USD",
       "decimals": 6,
       "erc20_contract_address": "0xB75D0B03c06A926e488e2659DF1A861F860bD3d1",
-      "denom": "0xB75D0B03c06A926e488e2659DF1A861F860bD3d1",
       "symbol": "USDT",
       "logo_uri": "https://raw.githubusercontent.com/axelarnetwork/axelar-configs/main/images/tokens/usdt.svg",
       "coingecko_id": "tether"

--- a/chains/137/assetlist.json
+++ b/chains/137/assetlist.json
@@ -19,7 +19,6 @@
             "name": "Polygon USDC",
             "decimals": 6,
             "erc20_contract_address": "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
-            "denom": "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
             "symbol": "USDC",
             "logo_uri": "https://raw.githubusercontent.com/axelarnetwork/axelar-configs/main/images/tokens/usdc.svg",
             "coingecko_id": "usd-coin",
@@ -30,7 +29,6 @@
             "name": "Dai Stablecoin",
             "decimals": 18,
             "erc20_contract_address": "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
-            "denom": "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
             "symbol": "DAI",
             "logo_uri": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063/logo.png",
             "coingecko_id": "dai"
@@ -40,7 +38,6 @@
             "name": "Tether USD",
             "decimals": 6,
             "erc20_contract_address": "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
-            "denom": "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
             "symbol": "USDT",
             "logo_uri": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0xc2132D05D31c914a87C6611C10748AEb04B58e8F/logo.png",
             "coingecko_id": "tether"
@@ -50,7 +47,6 @@
             "name": "Wrapped Ether",
             "decimals": 18,
             "erc20_contract_address": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
-            "denom": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
             "symbol": "WETH",
             "logo_uri": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619/logo.png",
             "coingecko_id": "weth"

--- a/chains/137/assetlist.json
+++ b/chains/137/assetlist.json
@@ -3,7 +3,8 @@
     "chain_name": "polygon",
     "assets": [
         {
-            "id": "polygon-native",
+            "asset_type": "evm_native",
+            "evm_native_asset_name": "polygon-native",
             "symbol": "POL",
             "name": "POL",
             "axelar_symbol": "WMATIC",
@@ -14,6 +15,7 @@
             "logo_uri": "https://raw.githubusercontent.com/axelarnetwork/axelar-docs/main/public/images/chains/polygon.svg"
         },
         {
+            "asset_type": "erc20",
             "name": "Polygon USDC",
             "decimals": 6,
             "erc20_contract_address": "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
@@ -24,6 +26,7 @@
             "go_fast_enabled": true
         },
         {
+            "asset_type": "erc20",
             "name": "Dai Stablecoin",
             "decimals": 18,
             "erc20_contract_address": "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
@@ -33,6 +36,7 @@
             "coingecko_id": "dai"
         },
         {
+            "asset_type": "erc20",
             "name": "Tether USD",
             "decimals": 6,
             "erc20_contract_address": "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
@@ -42,6 +46,7 @@
             "coingecko_id": "tether"
         },
         {
+            "asset_type": "erc20",
             "name": "Wrapped Ether",
             "decimals": 18,
             "erc20_contract_address": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",

--- a/chains/169/assetlist.json
+++ b/chains/169/assetlist.json
@@ -3,7 +3,8 @@
     "chain_name": "manta-pacific",
     "assets": [
         {
-            "id": "manta-pacific-native",
+            "asset_type": "evm_native",
+            "evm_native_asset_name": "manta-pacific-native",
             "symbol": "ETH",
             "name": "ETH",
             "decimals": 18,
@@ -11,6 +12,7 @@
             "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-blue.svg"
         },
         {
+            "asset_type": "erc20",
             "name": "TIA.n",
             "decimals": 6,
             "erc20_contract_address": "0x6Fae4D9935E2fcb11fC79a64e917fb2BF14DaFaa",

--- a/chains/169/assetlist.json
+++ b/chains/169/assetlist.json
@@ -16,7 +16,6 @@
             "name": "TIA.n",
             "decimals": 6,
             "erc20_contract_address": "0x6Fae4D9935E2fcb11fC79a64e917fb2BF14DaFaa",
-            "denom": "0x6Fae4D9935E2fcb11fC79a64e917fb2BF14DaFaa",
             "symbol": "TIA.n",
             "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/celestia/images/celestia.png",
             "coingecko_id": "bridged-tia-hyperlane"

--- a/chains/250/assetlist.json
+++ b/chains/250/assetlist.json
@@ -3,7 +3,8 @@
     "chain_name": "fantom",
     "assets": [
         {
-            "id": "fantom-native",
+            "asset_type": "evm_native",
+            "evm_native_asset_name": "fantom-native",
             "symbol": "FTM",
             "name": "Fantom",
             "axelar_symbol": "WFTM",

--- a/chains/314/assetlist.json
+++ b/chains/314/assetlist.json
@@ -3,7 +3,8 @@
     "chain_name": "filecoin",
     "assets": [
         {
-            "id": "filecoin-native",
+            "asset_type": "evm_native",
+            "evm_native_asset_name": "filecoin-native",
             "symbol": "FIL",
             "name": "FIL",
             "axelar_symbol": "WFIL",

--- a/chains/42161/assetlist.json
+++ b/chains/42161/assetlist.json
@@ -3,7 +3,8 @@
     "chain_name": "arbitrum",
     "assets": [
         {
-            "id": "arbitrum-native",
+            "asset_type": "evm_native",
+            "evm_native_asset_name": "arbitrum-native",
             "symbol": "ETH",
             "name": "ETH",
             "decimals": 18,
@@ -11,6 +12,7 @@
             "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-blue.svg"
         },
         {
+            "asset_type": "erc20",
             "name": "Arbitrum USDC",
             "decimals": 6,
             "erc20_contract_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
@@ -21,6 +23,7 @@
             "go_fast_enabled": true
         },
         {
+            "asset_type": "erc20",
             "name": "TIA.n",
             "decimals": 6,
             "erc20_contract_address": "0xD56734d7f9979dD94FAE3d67C7e928234e71cD4C",
@@ -30,6 +33,7 @@
             "coingecko_id": "bridged-tia-hyperlane"
         },
         {
+            "asset_type": "erc20",
             "name": "Dai Stablecoin",
             "decimals": 18,
             "erc20_contract_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
@@ -39,6 +43,7 @@
             "coingecko_id": "dai"
         },
         {
+            "asset_type": "erc20",
             "name": "Bridged USDC",
             "decimals": 6,
             "erc20_contract_address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
@@ -48,6 +53,7 @@
             "coingecko_id": "bridged-usdc-arbitrum"
         },
         {
+            "asset_type": "erc20",
             "name": "Tether USD",
             "decimals": 6,
             "erc20_contract_address": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
@@ -57,6 +63,7 @@
             "coingecko_id": "tether"
         },
         {
+            "asset_type": "erc20",
             "name": "Wrapped Ether",
             "decimals": 18,
             "erc20_contract_address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",

--- a/chains/42161/assetlist.json
+++ b/chains/42161/assetlist.json
@@ -16,7 +16,6 @@
             "name": "Arbitrum USDC",
             "decimals": 6,
             "erc20_contract_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
-            "denom": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
             "symbol": "USDC",
             "logo_uri": "https://raw.githubusercontent.com/axelarnetwork/axelar-configs/main/images/tokens/usdc.svg",
             "coingecko_id": "usd-coin",
@@ -27,7 +26,6 @@
             "name": "TIA.n",
             "decimals": 6,
             "erc20_contract_address": "0xD56734d7f9979dD94FAE3d67C7e928234e71cD4C",
-            "denom": "0xD56734d7f9979dD94FAE3d67C7e928234e71cD4C",
             "symbol": "TIA.n",
             "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/celestia/images/celestia.png",
             "coingecko_id": "bridged-tia-hyperlane"
@@ -37,7 +35,6 @@
             "name": "Dai Stablecoin",
             "decimals": 18,
             "erc20_contract_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
-            "denom": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
             "symbol": "DAI",
             "logo_uri": "https://assets-cdn.trustwallet.com/blockchains/arbitrum/assets/0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1/logo.png",
             "coingecko_id": "dai"
@@ -47,7 +44,6 @@
             "name": "Bridged USDC",
             "decimals": 6,
             "erc20_contract_address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
-            "denom": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
             "symbol": "USDC.e",
             "logo_uri": "https://assets-cdn.trustwallet.com/blockchains/arbitrum/assets/0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8/logo.png",
             "coingecko_id": "bridged-usdc-arbitrum"
@@ -57,7 +53,6 @@
             "name": "Tether USD",
             "decimals": 6,
             "erc20_contract_address": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
-            "denom": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
             "symbol": "USDT",
             "logo_uri": "https://assets-cdn.trustwallet.com/blockchains/arbitrum/assets/0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9/logo.png",
             "coingecko_id": "tether"
@@ -67,7 +62,6 @@
             "name": "Wrapped Ether",
             "decimals": 18,
             "erc20_contract_address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
-            "denom": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
             "symbol": "WETH",
             "logo_uri": "https://assets-cdn.trustwallet.com/blockchains/arbitrum/assets/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1/logo.png",
             "coingecko_id": "weth"

--- a/chains/421614/assetlist.json
+++ b/chains/421614/assetlist.json
@@ -7,7 +7,6 @@
             "name": "Arbitrum USDC",
             "decimals": 6,
             "erc20_contract_address": "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
-            "denom": "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
             "symbol": "USDC",
             "logo_uri": "https://raw.githubusercontent.com/axelarnetwork/axelar-configs/main/images/tokens/usdc.svg",
             "coingecko_id": "usd-coin"

--- a/chains/421614/assetlist.json
+++ b/chains/421614/assetlist.json
@@ -3,6 +3,7 @@
     "chain_name": "arbitrum-sepolia-testnet",
     "assets": [
         {
+            "asset_type": "erc20",
             "name": "Arbitrum USDC",
             "decimals": 6,
             "erc20_contract_address": "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",

--- a/chains/42220/assetlist.json
+++ b/chains/42220/assetlist.json
@@ -3,7 +3,8 @@
     "chain_name": "celo",
     "assets": [
         {
-            "id": "celo-native",
+            "asset_type": "evm_native",
+            "evm_native_asset_name": "celo-native",
             "symbol": "CELO",
             "name": "CELO",
             "decimals": 18,

--- a/chains/43113/assetlist.json
+++ b/chains/43113/assetlist.json
@@ -7,7 +7,6 @@
             "name": "Avalanche USDC",
             "decimals": 6,
             "erc20_contract_address": "0x5425890298aed601595a70ab815c96711a31bc65",
-            "denom": "0x5425890298aed601595a70ab815c96711a31bc65",
             "symbol": "USDC",
             "logo_uri": "https://raw.githubusercontent.com/axelarnetwork/axelar-configs/main/images/tokens/usdc.svg",
             "coingecko_id": "usd-coin"

--- a/chains/43113/assetlist.json
+++ b/chains/43113/assetlist.json
@@ -3,6 +3,7 @@
     "chain_name": "avalanche-fuji-testnet",
     "assets": [
         {
+            "asset_type": "erc20",
             "name": "Avalanche USDC",
             "decimals": 6,
             "erc20_contract_address": "0x5425890298aed601595a70ab815c96711a31bc65",

--- a/chains/43114/assetlist.json
+++ b/chains/43114/assetlist.json
@@ -19,7 +19,6 @@
             "name": "Avalanche USDC",
             "decimals": 6,
             "erc20_contract_address": "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",
-            "denom": "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",
             "symbol": "USDC",
             "logo_uri": "https://raw.githubusercontent.com/axelarnetwork/axelar-configs/main/images/tokens/usdc.svg",
             "coingecko_id": "usd-coin",

--- a/chains/43114/assetlist.json
+++ b/chains/43114/assetlist.json
@@ -3,7 +3,8 @@
     "chain_name": "avalanche",
     "assets": [
         {
-            "id": "avalanche-native",
+            "asset_type": "evm_native",
+            "evm_native_asset_name": "avalanche-native",
             "symbol": "AVAX",
             "name": "Avalanche",
             "axelar_symbol": "WAVAX",
@@ -14,6 +15,7 @@
             "logo_uri": "https://axelarscan.io/logos/chains/avalanche.svg"
         },
         {
+            "asset_type": "erc20",
             "name": "Avalanche USDC",
             "decimals": 6,
             "erc20_contract_address": "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",

--- a/chains/56/assetlist.json
+++ b/chains/56/assetlist.json
@@ -19,7 +19,6 @@
             "name": "Binance USD",
             "decimals": 18,
             "erc20_contract_address": "0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56",
-            "denom": "0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56",
             "symbol": "BUSD",
             "logo_uri": "https://assets-cdn.trustwallet.com/blockchains/smartchain/assets/0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56/logo.png",
             "coingecko_id": "busd"
@@ -29,7 +28,6 @@
             "name": "Binance ETH",
             "decimals": 18,
             "erc20_contract_address": "0x2170Ed0880ac9A755fd29B2688956BD959F933F8",
-            "denom": "0x2170Ed0880ac9A755fd29B2688956BD959F933F8",
             "symbol": "ETH",
             "logo_uri": "https://assets-cdn.trustwallet.com/blockchains/smartchain/assets/0x2170Ed0880ac9A755fd29B2688956BD959F933F8/logo.png",
             "coingecko_id": "ethereum"
@@ -39,7 +37,6 @@
             "name": "Polygon",
             "decimals": 18,
             "erc20_contract_address": "0xCC42724C6683B7E57334c4E856f4c9965ED682bD",
-            "denom": "0xCC42724C6683B7E57334c4E856f4c9965ED682bD",
             "symbol": "MATIC",
             "logo_uri": "https://assets-cdn.trustwallet.com/blockchains/smartchain/assets/0xCC42724C6683B7E57334c4E856f4c9965ED682bD/logo.png",
             "coingecko_id": "matic-network"
@@ -49,7 +46,6 @@
             "name": "Binance USDC",
             "decimals": 18,
             "erc20_contract_address": "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d",
-            "denom": "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d",
             "symbol": "USDC",
             "logo_uri": "https://assets-cdn.trustwallet.com/blockchains/smartchain/assets/0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d/logo.png",
             "coingecko_id": "usd-coin"
@@ -59,7 +55,6 @@
             "name": "Tether USD",
             "decimals": 18,
             "erc20_contract_address": "0x55d398326f99059fF775485246999027B3197955",
-            "denom": "0x55d398326f99059fF775485246999027B3197955",
             "symbol": "USDT",
             "logo_uri": "https://assets-cdn.trustwallet.com/blockchains/smartchain/assets/0x55d398326f99059fF775485246999027B3197955/logo.png",
             "coingecko_id": "tether"

--- a/chains/56/assetlist.json
+++ b/chains/56/assetlist.json
@@ -3,7 +3,8 @@
     "chain_name": "binance",
     "assets": [
         {
-            "id": "binance-native",
+            "asset_type": "evm_native",
+            "evm_native_asset_name": "binance-native",
             "symbol": "BNB",
             "name": "BNB",
             "axelar_symbol": "WBNB",
@@ -14,6 +15,7 @@
             "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/bnb.svg"
         },
         {
+            "asset_type": "erc20",
             "name": "Binance USD",
             "decimals": 18,
             "erc20_contract_address": "0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56",
@@ -23,6 +25,7 @@
             "coingecko_id": "busd"
         },
         {
+            "asset_type": "erc20",
             "name": "Binance ETH",
             "decimals": 18,
             "erc20_contract_address": "0x2170Ed0880ac9A755fd29B2688956BD959F933F8",
@@ -32,6 +35,7 @@
             "coingecko_id": "ethereum"
         },
         {
+            "asset_type": "erc20",
             "name": "Polygon",
             "decimals": 18,
             "erc20_contract_address": "0xCC42724C6683B7E57334c4E856f4c9965ED682bD",
@@ -41,6 +45,7 @@
             "coingecko_id": "matic-network"
         },
         {
+            "asset_type": "erc20",
             "name": "Binance USDC",
             "decimals": 18,
             "erc20_contract_address": "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d",
@@ -50,6 +55,7 @@
             "coingecko_id": "usd-coin"
         },
         {
+            "asset_type": "erc20",
             "name": "Tether USD",
             "decimals": 18,
             "erc20_contract_address": "0x55d398326f99059fF775485246999027B3197955",

--- a/chains/59144/assetlist.json
+++ b/chains/59144/assetlist.json
@@ -3,7 +3,8 @@
     "chain_name": "linea",
     "assets": [
         {
-            "id": "linea-native",
+            "asset_type": "evm_native",
+            "evm_native_asset_name": "linea-native",
             "symbol": "ETH",
             "name": "ETH",
             "decimals": 18,

--- a/chains/80002/assetlist.json
+++ b/chains/80002/assetlist.json
@@ -7,7 +7,6 @@
             "name": "Polygon USDC",
             "decimals": 6,
             "erc20_contract_address": "0x41e94eb019c0762f9bfcf9fb1e58725bfb0e7582",
-            "denom": "0x41e94eb019c0762f9bfcf9fb1e58725bfb0e7582",
             "symbol": "USDC",
             "logo_uri": "https://raw.githubusercontent.com/axelarnetwork/axelar-configs/main/images/tokens/usdc.svg",
             "coingecko_id": "usd-coin"

--- a/chains/80002/assetlist.json
+++ b/chains/80002/assetlist.json
@@ -3,6 +3,7 @@
     "chain_name": "polygon-sepolia-testnet",
     "assets": [
         {
+            "asset_type": "erc20",
             "name": "Polygon USDC",
             "decimals": 6,
             "erc20_contract_address": "0x41e94eb019c0762f9bfcf9fb1e58725bfb0e7582",

--- a/chains/81457/assetlist.json
+++ b/chains/81457/assetlist.json
@@ -3,7 +3,8 @@
     "chain_name": "blast",
     "assets": [
         {
-            "id": "blast-native",
+            "asset_type": "evm_native",
+            "evm_native_asset_name": "blast-native",
             "symbol": "ETH",
             "name": "ETH",
             "decimals": 18,

--- a/chains/8453/assetlist.json
+++ b/chains/8453/assetlist.json
@@ -16,7 +16,6 @@
             "name": "Base USDC",
             "decimals": 6,
             "erc20_contract_address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-            "denom": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
             "symbol": "USDC",
             "logo_uri": "https://raw.githubusercontent.com/axelarnetwork/axelar-configs/main/images/tokens/usdc.svg",
             "coingecko_id": "usd-coin",

--- a/chains/8453/assetlist.json
+++ b/chains/8453/assetlist.json
@@ -3,7 +3,8 @@
     "chain_name": "base",
     "assets": [
         {
-            "id": "base-native",
+            "asset_type": "evm_native",
+            "evm_native_asset_name": "base-native",
             "symbol": "ETH",
             "name": "ETH",
             "decimals": 18,
@@ -11,6 +12,7 @@
             "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-blue.svg"
         },
         {
+            "asset_type": "erc20",
             "name": "Base USDC",
             "decimals": 6,
             "erc20_contract_address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",

--- a/chains/84532/assetlist.json
+++ b/chains/84532/assetlist.json
@@ -3,6 +3,7 @@
     "chain_name": "base-sepolia-testnet",
     "assets": [
         {
+            "asset_type": "erc20",
             "name": "Base USDC",
             "decimals": 6,
             "erc20_contract_address": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",

--- a/chains/84532/assetlist.json
+++ b/chains/84532/assetlist.json
@@ -7,7 +7,6 @@
             "name": "Base USDC",
             "decimals": 6,
             "erc20_contract_address": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
-            "denom": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
             "symbol": "USDC",
             "logo_uri": "https://raw.githubusercontent.com/axelarnetwork/axelar-configs/main/images/tokens/usdc.svg",
             "coingecko_id": "usd-coin"

--- a/chains/984122/assetlist.json
+++ b/chains/984122/assetlist.json
@@ -3,7 +3,8 @@
     "chain_name": "forma",
     "assets": [
         {
-            "id": "forma-native",
+            "asset_type": "evm_native",
+            "evm_native_asset_name": "forma-native",
             "symbol": "TIA",
             "name": "TIA",
             "decimals": 18,

--- a/chains/984123/assetlist.json
+++ b/chains/984123/assetlist.json
@@ -3,7 +3,8 @@
     "chain_name": "forma-tesetnet",
     "assets": [
         {
-            "id": "forma-testnet-native",
+            "asset_type": "evm_native",
+            "evm_native_asset_name": "forma-testnet-native",
             "symbol": "TIA",
             "name": "TIA",
             "decimals": 18,

--- a/chains/osmosis-1/assetlist.json
+++ b/chains/osmosis-1/assetlist.json
@@ -3,6 +3,7 @@
     "chain_name": "osmosis",
     "assets": [
         {
+            "asset_type": "cosmos", 
             "name": "Osmosis USDC",
             "decimals": 6,
             "symbol": "USDC",

--- a/chains/pacific-1/assetlist.json
+++ b/chains/pacific-1/assetlist.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "../../assetlist.schema.json",
+    "chain_name": "sei",
+    "assets": [
+        {
+            "asset_type": "cosmos", 
+            "name": "USDT",
+            "decimals": 6,
+            "symbol": "USDT",
+            "recommended_symbol": "USDT",
+            "denom": "ibc/6C00E4AA0CC7618370F81F7378638AE6C48EFF8C9203CE1C2357012B440EBDB7",
+            "logo_uri": "https://raw.githubusercontent.com/axelarnetwork/axelar-configs/main/images/tokens/usdt.svg",
+            "coingecko_id": "tether"
+        }
+    ]
+}


### PR DESCRIPTION
Currently in the asset list schema, there are fields that are marked as required that are not actually required. These fields are now optional (`symbol`, `coiingeckoid`, `decimals`, `logo_uri`). This also makes one of either `id`, `denom`, or `erc20_contract_address`, require for an asset.