### PR TITLE
Replace Solana Chain Logo Image

### DIFF
--- a/chains/solana-devnet/logo.svg
+++ b/chains/solana-devnet/logo.svg
@@ -1,28 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 24.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 397.7 311.7" style="enable-background:new 0 0 397.7 311.7;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:url(#SVGID_1_);}
-	.st1{fill:url(#SVGID_2_);}
-	.st2{fill:url(#SVGID_3_);}
-</style>
-<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="360.8791" y1="351.4553" x2="141.213" y2="-69.2936" gradientTransform="matrix(1 0 0 -1 0 314)">
-	<stop  offset="0" style="stop-color:#00FFA3"/>
-	<stop  offset="1" style="stop-color:#DC1FFF"/>
+<svg width="500" height="500" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M249.796 0H250.205C388.139 0 500 108.921 500 243.23V256.77C500 391.079 388.139 500 250.205 500H249.796C111.861 500 0 391.079 0 256.77V243.23C0 108.921 111.861 0 249.796 0Z" fill="#232323"/>
+<path d="M351.757 188.387C350.948 189.284 349.936 189.981 348.824 190.379C347.711 190.877 346.497 191.077 345.284 191.077H116.19C108.099 191.077 103.952 181.115 109.616 175.138L147.242 135.789C148.051 134.893 149.062 134.195 150.276 133.697C151.389 133.199 152.602 133 153.816 133H383.82C392.013 133 396.059 143.061 390.293 149.038L351.757 188.387ZM351.757 364.31C350.038 366.004 347.711 367 345.284 367H116.19C108.099 367 103.952 357.238 109.616 351.46L147.242 313.008C148.051 312.111 149.164 311.414 150.276 311.015C151.389 310.517 152.602 310.318 153.816 310.318H383.82C392.013 310.318 396.059 320.18 390.293 325.958L351.757 364.31ZM351.757 224.349C350.038 222.655 347.711 221.659 345.284 221.659H116.19C108.099 221.659 103.952 231.421 109.616 237.199L147.242 275.651C148.051 276.548 149.164 277.245 150.276 277.644C151.389 278.142 152.602 278.341 153.816 278.341H383.82C392.013 278.341 396.059 268.479 390.293 262.701L351.757 224.349Z" fill="url(#paint0_linear_1273_5)"/>
+<defs>
+<linearGradient id="paint0_linear_1273_5" x1="124.488" y1="369.92" x2="371.047" y2="126.193" gradientUnits="userSpaceOnUse">
+<stop stop-color="#CF41E8"/>
+<stop offset="1" stop-color="#10F2B0"/>
 </linearGradient>
-<path class="st0" d="M64.6,237.9c2.4-2.4,5.7-3.8,9.2-3.8h317.4c5.8,0,8.7,7,4.6,11.1l-62.7,62.7c-2.4,2.4-5.7,3.8-9.2,3.8H6.5
-	c-5.8,0-8.7-7-4.6-11.1L64.6,237.9z"/>
-<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="264.8291" y1="401.6014" x2="45.163" y2="-19.1475" gradientTransform="matrix(1 0 0 -1 0 314)">
-	<stop  offset="0" style="stop-color:#00FFA3"/>
-	<stop  offset="1" style="stop-color:#DC1FFF"/>
-</linearGradient>
-<path class="st1" d="M64.6,3.8C67.1,1.4,70.4,0,73.8,0h317.4c5.8,0,8.7,7,4.6,11.1l-62.7,62.7c-2.4,2.4-5.7,3.8-9.2,3.8H6.5
-	c-5.8,0-8.7-7-4.6-11.1L64.6,3.8z"/>
-<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="312.5484" y1="376.688" x2="92.8822" y2="-44.061" gradientTransform="matrix(1 0 0 -1 0 314)">
-	<stop  offset="0" style="stop-color:#00FFA3"/>
-	<stop  offset="1" style="stop-color:#DC1FFF"/>
-</linearGradient>
-<path class="st2" d="M333.1,120.1c-2.4-2.4-5.7-3.8-9.2-3.8H6.5c-5.8,0-8.7,7-4.6,11.1l62.7,62.7c2.4,2.4,5.7,3.8,9.2,3.8h317.4
-	c5.8,0,8.7-7,4.6-11.1L333.1,120.1z"/>
+</defs>
 </svg>

--- a/chains/solana/logo.svg
+++ b/chains/solana/logo.svg
@@ -1,28 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 24.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 397.7 311.7" style="enable-background:new 0 0 397.7 311.7;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:url(#SVGID_1_);}
-	.st1{fill:url(#SVGID_2_);}
-	.st2{fill:url(#SVGID_3_);}
-</style>
-<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="360.8791" y1="351.4553" x2="141.213" y2="-69.2936" gradientTransform="matrix(1 0 0 -1 0 314)">
-	<stop  offset="0" style="stop-color:#00FFA3"/>
-	<stop  offset="1" style="stop-color:#DC1FFF"/>
+<svg width="500" height="500" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M249.796 0H250.205C388.139 0 500 108.921 500 243.23V256.77C500 391.079 388.139 500 250.205 500H249.796C111.861 500 0 391.079 0 256.77V243.23C0 108.921 111.861 0 249.796 0Z" fill="#232323"/>
+<path d="M351.757 188.387C350.948 189.284 349.936 189.981 348.824 190.379C347.711 190.877 346.497 191.077 345.284 191.077H116.19C108.099 191.077 103.952 181.115 109.616 175.138L147.242 135.789C148.051 134.893 149.062 134.195 150.276 133.697C151.389 133.199 152.602 133 153.816 133H383.82C392.013 133 396.059 143.061 390.293 149.038L351.757 188.387ZM351.757 364.31C350.038 366.004 347.711 367 345.284 367H116.19C108.099 367 103.952 357.238 109.616 351.46L147.242 313.008C148.051 312.111 149.164 311.414 150.276 311.015C151.389 310.517 152.602 310.318 153.816 310.318H383.82C392.013 310.318 396.059 320.18 390.293 325.958L351.757 364.31ZM351.757 224.349C350.038 222.655 347.711 221.659 345.284 221.659H116.19C108.099 221.659 103.952 231.421 109.616 237.199L147.242 275.651C148.051 276.548 149.164 277.245 150.276 277.644C151.389 278.142 152.602 278.341 153.816 278.341H383.82C392.013 278.341 396.059 268.479 390.293 262.701L351.757 224.349Z" fill="url(#paint0_linear_1273_5)"/>
+<defs>
+<linearGradient id="paint0_linear_1273_5" x1="124.488" y1="369.92" x2="371.047" y2="126.193" gradientUnits="userSpaceOnUse">
+<stop stop-color="#CF41E8"/>
+<stop offset="1" stop-color="#10F2B0"/>
 </linearGradient>
-<path class="st0" d="M64.6,237.9c2.4-2.4,5.7-3.8,9.2-3.8h317.4c5.8,0,8.7,7,4.6,11.1l-62.7,62.7c-2.4,2.4-5.7,3.8-9.2,3.8H6.5
-	c-5.8,0-8.7-7-4.6-11.1L64.6,237.9z"/>
-<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="264.8291" y1="401.6014" x2="45.163" y2="-19.1475" gradientTransform="matrix(1 0 0 -1 0 314)">
-	<stop  offset="0" style="stop-color:#00FFA3"/>
-	<stop  offset="1" style="stop-color:#DC1FFF"/>
-</linearGradient>
-<path class="st1" d="M64.6,3.8C67.1,1.4,70.4,0,73.8,0h317.4c5.8,0,8.7,7,4.6,11.1l-62.7,62.7c-2.4,2.4-5.7,3.8-9.2,3.8H6.5
-	c-5.8,0-8.7-7-4.6-11.1L64.6,3.8z"/>
-<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="312.5484" y1="376.688" x2="92.8822" y2="-44.061" gradientTransform="matrix(1 0 0 -1 0 314)">
-	<stop  offset="0" style="stop-color:#00FFA3"/>
-	<stop  offset="1" style="stop-color:#DC1FFF"/>
-</linearGradient>
-<path class="st2" d="M333.1,120.1c-2.4-2.4-5.7-3.8-9.2-3.8H6.5c-5.8,0-8.7,7-4.6,11.1l62.7,62.7c2.4,2.4,5.7,3.8,9.2,3.8h317.4
-	c5.8,0,8.7-7,4.6-11.1L333.1,120.1z"/>
+</defs>
 </svg>


### PR DESCRIPTION
- The previous logo looked zoomed in/blurry since our widget has a rounded border around the logo and it was designed for a square
- This new logo that replaces it is the one used for our SOL assets and looks clearer since it is within a circle already