### PR TITLE
fix: add opinit symbol overrides for Initia L2 chains

### DIFF
--- a/chains/bfb-1/assetlist.json
+++ b/chains/bfb-1/assetlist.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "../../assetlist.schema.json",
+    "chain_name": "bfb",
+    "assets": [
+        {
+            "asset_type": "cosmos",
+            "denom": "evm/6ed1637781269560b204c27Cd42d95e057C4BE44",
+            "recommended_symbol": "INIT.opinit"
+        }
+    ]
+}

--- a/chains/embrmainnet-1/assetlist.json
+++ b/chains/embrmainnet-1/assetlist.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "../../assetlist.schema.json",
+    "chain_name": "embrmainnet",
+    "assets": [
+        {
+            "asset_type": "cosmos",
+            "denom": "evm/4f7566f67941283a30cf65de7b9c6fdf2c04FCA1",
+            "recommended_symbol": "INIT.opinit"
+        }
+    ]
+}

--- a/chains/intergaze-1/assetlist.json
+++ b/chains/intergaze-1/assetlist.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "../../assetlist.schema.json",
+    "chain_name": "intergaze",
+    "assets": [
+        {
+            "asset_type": "cosmos",
+            "denom": "l2/db147f1ded7ffcc336f5f8d1eff83c4feb95fcfff5c84f1b9c135444b816e48e",
+            "recommended_symbol": "USDC.opinit"
+        }
+    ]
+}

--- a/chains/rave-1/assetlist.json
+++ b/chains/rave-1/assetlist.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "../../assetlist.schema.json",
+    "chain_name": "rave",
+    "assets": [
+        {
+            "asset_type": "cosmos",
+            "denom": "evm/4f7566f67941283a30cf65de7b9c6fdf2c04FCA1",
+            "recommended_symbol": "INIT.opinit"
+        }
+    ]
+}


### PR DESCRIPTION
- bfb-1: Add INIT.opinit override for native EVM INIT token
- embrmainnet-1: Add INIT.opinit override for native EVM INIT token
- intergaze-1: Add USDC.opinit override for native L2 USDC token
- rave-1: Add INIT.opinit override for native EVM INIT token

These overrides disambiguate native L2 tokens (using opinit bridge) from IBC versions of the same assets by adding .opinit suffix to recommended_symbol field.