### PR TITLE
override usdc axelar name

### DIFF
--- a/chains/1/assetlist.json
+++ b/chains/1/assetlist.json
@@ -32,7 +32,8 @@
             "symbol": "USDC",
             "logo_uri": "https://raw.githubusercontent.com/axelarnetwork/axelar-configs/main/images/tokens/usdc.svg",
             "coingecko_id": "usd-coin",
-            "go_fast_enabled": true
+            "go_fast_enabled": true,
+            "axelar_name": "uusdc"
         },
         {
             "asset_type": "erc20",


### PR DESCRIPTION
The Axelar config we are pulling from is currently broken, setting USDC axelar_name here to fix some broken routes