### PR TITLE
Add XRPL EVM chain config with logo override

### DIFF
--- a/chains/xrplevm_1440000-1/chain.json
+++ b/chains/xrplevm_1440000-1/chain.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "../../chain.schema.json",
+    "chain_id": "xrplevm_1440000-1",
+    "is_testnet": false,
+    "chain_name": "xrplevm",
+    "chain_type": "cosmos",
+    "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/xrpl/images/xrp.png"
+}


### PR DESCRIPTION
Added minimal chain configuration for XRPL EVM (xrplevm_1440000-1) to provide logo URI for this chain.