### PR TITLE
Add INIT.ibc symbol override for IBC INIT tokens on Initia L2s

### DIFF
--- a/chains/bfb-1/assetlist.json
+++ b/chains/bfb-1/assetlist.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../assetlist.schema.json",
+  "chain_name": "bfb",
+  "assets": [
+    {
+      "asset_type": "cosmos",
+      "denom": "ibc/37A3FB4FED4CA04ED6D9E5DA36C6D27248645F0E22F585576A1488B8A89C5A50",
+      "recommended_symbol": "INIT.ibc"
+    }
+  ]
+}

--- a/chains/echelon-1/assetlist.json
+++ b/chains/echelon-1/assetlist.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../assetlist.schema.json",
+  "chain_name": "echelon",
+  "assets": [
+    {
+      "asset_type": "cosmos",
+      "denom": "ibc/37A3FB4FED4CA04ED6D9E5DA36C6D27248645F0E22F585576A1488B8A89C5A50",
+      "recommended_symbol": "INIT.ibc"
+    }
+  ]
+}

--- a/chains/embrmainnet-1/assetlist.json
+++ b/chains/embrmainnet-1/assetlist.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../assetlist.schema.json",
+  "chain_name": "embr",
+  "assets": [
+    {
+      "asset_type": "cosmos",
+      "denom": "ibc/37A3FB4FED4CA04ED6D9E5DA36C6D27248645F0E22F585576A1488B8A89C5A50",
+      "recommended_symbol": "INIT.ibc"
+    }
+  ]
+}

--- a/chains/intergaze-1/assetlist.json
+++ b/chains/intergaze-1/assetlist.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../assetlist.schema.json",
+  "chain_name": "intergaze",
+  "assets": [
+    {
+      "asset_type": "cosmos",
+      "denom": "ibc/37A3FB4FED4CA04ED6D9E5DA36C6D27248645F0E22F585576A1488B8A89C5A50",
+      "recommended_symbol": "INIT.ibc"
+    }
+  ]
+}

--- a/chains/rena-nuwa-1/assetlist.json
+++ b/chains/rena-nuwa-1/assetlist.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../assetlist.schema.json",
+  "chain_name": "rena",
+  "assets": [
+    {
+      "asset_type": "cosmos",
+      "denom": "ibc/37A3FB4FED4CA04ED6D9E5DA36C6D27248645F0E22F585576A1488B8A89C5A50",
+      "recommended_symbol": "INIT.ibc"
+    }
+  ]
+}


### PR DESCRIPTION
- Added minimal assetlist.json files for Initia L2 chains
- Only added recommended_symbol: "INIT.ibc" for IBC-bridged INIT tokens
- Fixed chain_name to match chain.json values (not chain_id)
- Affected chains: bfb-1, echelon-1, embrmainnet-1, intergaze-1, rena-nuwa-1