### PR TITLE
FRE-2050: Fix duplicate CELO on chain 42220

### DIFF
--- a/chains/42220/assetlist.json
+++ b/chains/42220/assetlist.json
@@ -33,6 +33,13 @@
             "symbol": "FRAX",
             "coingecko_id": "frax-share",
             "recommended_symbol": "FRAX"
+        },
+        {
+            "asset_type": "erc20",
+            "erc20_contract_address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+            "logo_uri": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/celo/info/logo.png",
+            "coingecko_id": "celo",
+            "recommended_symbol": "WCELO"
         }
     ]
 }


### PR DESCRIPTION
## Summary
- Add CELO ERC20 contract (0x471EcE3750Da237f93B8E339c536989b8978a438) to registry
- Use recommended_symbol "WCELO" to differentiate from native CELO
- This prevents duplicate CELO entries in the API response 

