### PR TITLE
Add BitSong (BTSG) IBC token to Neutron

### DIFF
--- a/chains/neutron-1/assetlist.json
+++ b/chains/neutron-1/assetlist.json
@@ -1,22 +1,30 @@
 {
-    "$schema": "../../assetlist.schema.json",
-    "chain_name": "neutron",
-    "assets": [
-        {
-            "asset_type": "cosmos",
-            "name": "WETH.axl",
-            "symbol": "WETH.axl",
-            "denom": "ibc/A585C2D15DCD3B010849B453A2CFCB5E213208A5AB665691792684C26274304D",
-            "recommended_symbol": "WETH.axl",
-            "coingecko_id": "weth"
-        },
-        {
-            "asset_type": "cosmos",
-            "name": "ETH",
-            "symbol": "ETH",
-            "denom": "ibc/694A6B26A43A2FBECCFFEAC022DEACB39578E54207FDD32005CD976B57B98004",
-            "recommended_symbol": "ETH",
-            "coingecko_id": "ethereum"
-        }
-    ]
+  "$schema": "../../assetlist.schema.json",
+  "chain_name": "neutron",
+  "assets": [
+    {
+      "asset_type": "cosmos",
+      "name": "WETH.axl",
+      "symbol": "WETH.axl",
+      "denom": "ibc/A585C2D15DCD3B010849B453A2CFCB5E213208A5AB665691792684C26274304D",
+      "recommended_symbol": "WETH.axl",
+      "coingecko_id": "weth"
+    },
+    {
+      "asset_type": "cosmos",
+      "name": "ETH",
+      "symbol": "ETH",
+      "denom": "ibc/694A6B26A43A2FBECCFFEAC022DEACB39578E54207FDD32005CD976B57B98004",
+      "recommended_symbol": "ETH",
+      "coingecko_id": "ethereum"
+    },
+    {
+      "asset_type": "cosmos",
+      "name": "BitSong",
+      "symbol": "BTSG",
+      "denom": "ibc/53E1B5B1C060CF4B556E91020EACD272CD9160E996E598FC93D2436814050471",
+      "recommended_symbol": "BTSG",
+      "coingecko_id": "bitsong"
+    }
+  ]
 }


### PR DESCRIPTION
## Description
Adds BitSong (BTSG) IBC token metadata to the Neutron assetlist.

## Problem
BTSG tokens transferred from BitSong to Neutron via IBC are not visible in Skip App because the IBC token metadata is missing from the registry.

## Solution
Add the BTSG IBC token entry with proper metadata to make it visible.

## Token Details
- **IBC Denom**: `ibc/53E1B5B1C060CF4B556E91020EACD272CD9160E996E598FC93D2436814050471`
- **Origin Chain**: BitSong (bitsong-2b)
- **Origin Denom**: ubtsg
- **IBC Path**: transfer/channel-7232
- **CoinGecko ID**: bitsong

## Testing
After merging, BTSG tokens on Neutron should:
1. Appear in the Skip API response
2. Be visible in Skip App
3. Display proper metadata (name, symbol)

## References
- [BitSong Chain Registry](https://github.com/cosmos/chain-registry/tree/master/bitsong)
- [Example Transaction](https://explorer.chainroot.io/bitsong/transactions/4D83D2D77BDFC1FF452C96591D239F90B8FACB3B855D945B21340C85A59D6643)