### PR TITLE
Add ZIG asset with symbol override to Cosmos Hub

### DIFF
--- a/chains/cosmoshub-4/assetlist.json
+++ b/chains/cosmoshub-4/assetlist.json
@@ -43,6 +43,11 @@
             "denom": "ibc/3D0840AB3557CC2940D100C1633690143AB4F392AF969EB0660142A9A5B1FE74",
             "symbol": "wstETH.neutron",
             "recommended_symbol": "wstETH.neutron"
+        },
+        {
+            "asset_type": "cosmos",
+            "denom": "ibc/A80B50FB9B688DA92501D3DEC51A5B64DBE962C604F5834CF6B1B6D4316C5E4B",
+            "recommended_symbol": "z"
         }
     ]
 }


### PR DESCRIPTION
## Summary
- Add ZIG token from zigchain-1 to cosmoshub-4 assetlist
- Set recommended_symbol to "z" for proper display in Skip interface
- Enables symbol override for IBC denom `ibc/A80B50FB9B688DA92501D3DEC51A5B64DBE962C604F5834CF6B1B6D4316C5E4B`

## Test plan
- [ ] Verify asset appears with symbol "z" in Skip interface
- [ ] Confirm IBC denom matches the bridged ZIG token from zigchain-1
- [ ] Test asset registry validation passes