### PR TITLE
Add ZIG asset metadata for axelar-dojo-1 chain

### DIFF
--- a/chains/axelar-dojo-1/assetlist.json
+++ b/chains/axelar-dojo-1/assetlist.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../assetlist.schema.json",
+  "chain_name": "axelar",
+  "assets": [
+    {
+      "asset_type": "cosmos",
+      "name": "ZIG",
+      "decimals": 18,
+      "symbol": "ZIG",
+      "denom": "unit-zig",
+      "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/zigchain/images/zigchain.png",
+      "coingecko_id": "zignaly",
+      "recommended_symbol": "ZIG"
+    }
+  ]
+}

--- a/chains/axelar-dojo-1/chain.json
+++ b/chains/axelar-dojo-1/chain.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../chain.schema.json",
+  "chain_id": "axelar-dojo-1",
+  "is_testnet": false,
+  "chain_name": "axelar",
+  "chain_type": "cosmos"
+}


### PR DESCRIPTION
## Summary
- Add new axelar-dojo-1 chain configuration
- Add ZIG asset metadata with symbol, logo, coingecko ID, and recommended symbol
- Asset uses denom `unit-zig` on Axelar

## Test plan
- [ ] Verify chain.json follows schema
- [ ] Verify assetlist.json follows schema  
- [ ] Confirm ZIG asset metadata is complete