### PR TITLE
Add decimals field to ETH asset on yominet-1

### DIFF
--- a/chains/yominet-1/assetlist.json
+++ b/chains/yominet-1/assetlist.json
@@ -6,6 +6,7 @@
             "asset_type": "cosmos",
             "symbol": "ETH",
             "denom": "evm/E1Ff7038eAAAF027031688E1535a055B2Bac2546",
+            "decimals": 6,
             "recommended_symbol": "ETH.lz",
             "coingecko_id": "ethereum"
         }


### PR DESCRIPTION
## Summary
- Added `decimals: 6` field to the ETH asset on yominet-1 chain
- Asset denom: `evm/E1Ff7038eAAAF027031688E1535a055B2Bac2546`

## Changes
- Updated `/chains/yominet-1/assetlist.json` to include the decimals field for the ETH asset