### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+** @skip-mev/ecosystem-team


### PR DESCRIPTION
Adds `.github/CODEOWNERS` to assign `@skip-mev/stack-team` as code owners for all files.