### PR TITLE
AUSD0 => AUSD

### DIFF
--- a/chains/interwoven-1/assetlist.json
+++ b/chains/interwoven-1/assetlist.json
@@ -301,11 +301,11 @@
     },
     {
       "asset_type": "cosmos",
-      "symbol": "AUSD0",
-      "name": "AUSD0",
+      "symbol": "AUSD",
+      "name": "AUSD",
       "denom": "move/8078cf9fee50e15069402e9d1d9db70b28fc0d5197d79e8a2b41e2ade432efef",
-      "logo_uri": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/AUSD0.png",
-      "recommended_symbol": "AUSD0",
+      "logo_uri": "https://raw.githubusercontent.com/initia-labs/initia-registry/main/images/AUSD.png",
+      "recommended_symbol": "AUSD",
       "decimals": 6
     },
     {


### PR DESCRIPTION
## Problem

The Initia registry uses `AUSD`, while the skip-go-registry is configured with `AUSD0`.

- https://github.com/initia-labs/initia-registry/blob/main/images/AUSD.png
- https://github.com/initia-labs/initia-registry/blob/86a6c77a9b6d372262a80f6d3d33c4cb2967e623/mainnets/initia/assetlist.json#L1160