### PR TITLE
feat: add hotake-1 (Hot Take) mainnet rollup

### DIFF
--- a/chains/hotake-1/assetlist.json
+++ b/chains/hotake-1/assetlist.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../assetlist.schema.json",
+  "chain_name": "hotake",
+  "assets": [
+    {
+      "asset_type": "cosmos",
+      "denom": "ibc/B82A5B2051D2296EE838D076218D4F852A629C69B99E7430C4D388F37DB16A3A",
+      "symbol": "iUSD",
+      "name": "iUSD",
+      "logo_uri": "https://raw.githubusercontent.com/skip-mev/skip-go-registry/main/chains/interwoven-1/images/iUSD.png",
+      "recommended_symbol": "iUSD.ibc",
+      "decimals": 6
+    }
+  ]
+}

--- a/chains/hotake-1/chain.json
+++ b/chains/hotake-1/chain.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../../initia.chain.schema.json",
+  "chain_id": "hotake-1",
+  "is_testnet": false,
+  "chain_name": "hotake",
+  "chain_type": "initia",
+  "is_initia_l1": false,
+  "initia_l1_chain_id": "interwoven-1",
+  "apis": {
+    "tendermint_rpc_endpoint": {
+      "address": "https://rpc-hotake-1.anvil.asia-southeast.initia.xyz",
+      "backoff_delay": 1000
+    },
+    "lcd_rest_endpoint": {
+      "address": "https://rest-hotake-1.anvil.asia-southeast.initia.xyz",
+      "backoff_delay": 1000
+    },
+    "cosmos_sdk_grpc_endpoint": {
+      "address": "grpc-hotake-1.anvil.asia-southeast.initia.xyz:443",
+      "backoff_delay": 0,
+      "tls": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds Hot Take (`hotake-1`) as a new mainnet Initia L2 (minievm rollup). Two files added under `chains/hotake-1/`:

- `chain.json` — slim Initia config (RPC/REST/gRPC at `*.anvil.asia-southeast.initia.xyz`, `chain_type: initia`, L1 = `interwoven-1`).
- `assetlist.json` — single iUSD asset, IBC-bridged from interwoven-1.

Companion to **initia-labs/initia-registry#831** (merged 2026-05-06), which adds the canonical `mainnets/hotake/` entry plus the `interwoven-1` ↔ `hotake-1` IBC channel pair (`channel-108` ↔ `channel-0`).

## Asset shape — decisions

iUSD reaches `hotake-1` from `interwoven-1` over IBC (`channel-108` → `channel-0`), landing as a cosmos-bank IBC denom on hotake. A Decimal Wrapper contract on hotake then re-wraps it into an 18-decimal ERC20 for EVM/wallet UX. Skip routes through the cosmos-bank denom, so this entry mirrors the existing Skip convention for IBC-bridged iUSD on other Initia L2s.

| Field | Value | Reasoning |
|---|---|---|
| `denom` | `ibc/B82A5B2051D2296EE838D076218D4F852A629C69B99E7430C4D388F37DB16A3A` | The cosmos-bank IBC denom that lands on hotake from interwoven. Matches the IBC trace declared in initia-labs/initia-registry#831. Identical hash already used for IBC iUSD on `civitia-1` and `echelon-1`. |
| `decimals` | `6` | Decimals of the bank denom (matches the underlying L1 iUSD scale). The 18-dec figure that wallets surface is post-Decimal-Wrapper, which Skip doesn't route. Matches civitia/echelon convention. |
| `recommended_symbol` | `iUSD.ibc` | Mirrors the `iUSD.ibc` already used by `civitia-1` and `echelon-1` for the same `ibc/B82A5B…` denom. |
| `asset_type` | `cosmos` | Skip routes through cosmos bank, even on EVM rollups (matches civitia/echelon). |
| `logo_uri` | `…/skip-go-registry/main/chains/interwoven-1/images/iUSD.png` | Reuses existing in-repo iUSD logo (same convention as civitia/echelon). No new image committed. |

INIT is not included in this initial entry — no canonical wrapped-INIT ERC20 has been deployed on hotake-1 yet, so listing it would create a stuck-funds risk. Can be added in a follow-up once a wrapper exists.

## Reference

- Template PR (single Initia L2 mainnet add, same minimal field set): #269 (strat mainnet)
- Other minievm chains in this repo using the same `ibc/B82A5B…` iUSD shape: `chains/civitia-1/assetlist.json`, `chains/echelon-1/assetlist.json`

## Local verification

Ran the validators that this repo's `.github/workflows/config_validation.yml` invokes:

- `validate-initia.ts chains/hotake-1/chain.json` — schema, registry cross-check, gRPC/RPC/REST liveness, IBC channel + client queries: **16/16 pass**.
- `validate-schema.ts assetlist.schema.json chains/hotake-1/assetlist.json` — **pass**.
- Cross-repo consistency vs initia-labs/initia-registry#831 (chain_id, chain_name, endpoints, IBC trace counterparty hash, logo URL existence, no accidental `bridges/opinit/` or numeric-EVM-id directories): **26/26 pass**.
- RPC `/status` reports `node_info.network = hotake-1`; REST and gRPC echo the same.

## Test plan

- [ ] Skip's CI (`config_validation.yml`) green on this PR
- [ ] Reviewers confirm IBC-bridged asset shape (Q on `decimals: 6` vs `18` is intentional — see table above)
- [ ] Post-merge: monitor a small iUSD swap into/out of hotake-1 via Skip Go API to confirm routing

## Notes for reviewers

- Skip Go API ingestion of `hotake-1` cannot be validated pre-merge; routing tests only become possible after this lands and Skip's backend re-ingests.
- This PR is intentionally iUSD-only. INIT and any other future hotake-1 assets will arrive in follow-ups once their canonical denoms exist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new mainnet chain entry and asset metadata that will be consumed by routing/ingestion; risk is mainly from incorrect endpoints or denom metadata causing failed queries or misrouted transfers.
> 
> **Overview**
> Registers the new Initia L2 mainnet `hotake-1` by adding `chains/hotake-1/chain.json` with RPC/REST/gRPC endpoints and linking it to the L1 `interwoven-1`.
> 
> Adds `chains/hotake-1/assetlist.json` with a single IBC `iUSD` (6 decimals) asset entry, including logo URI and `recommended_symbol` for consistent display/routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e89b1e55f8be0ff6c091926b6bbf56df3c58b83c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->