### PR TITLE
add for eth erc20s

### DIFF
--- a/chains/1/assetlist.json
+++ b/chains/1/assetlist.json
@@ -16,6 +16,36 @@
         },
         {
             "asset_type": "erc20",
+            "name": "Lido Staked Ether",
+            "decimals": 18,
+            "erc20_contract_address": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+            "symbol": "stETH",
+            "logo_uri": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84/logo.png",
+            "coingecko_id": "staked-ether",
+            "recommended_symbol": "stETH"
+        },
+        {
+            "asset_type": "erc20",
+            "name": "Wrapped stETH",
+            "decimals": 18,
+            "erc20_contract_address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+            "symbol": "wstETH",
+            "logo_uri": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0/logo.png",
+            "coingecko_id": "wrapped-steth",
+            "recommended_symbol": "wstETH"
+        },
+        {
+            "asset_type": "erc20",
+            "name": "Euro Coin",
+            "decimals": 6,
+            "erc20_contract_address": "0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c",
+            "symbol": "EURC",
+            "logo_uri": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c/logo.png",
+            "coingecko_id": "euro-coin",
+            "recommended_symbol": "EURC"
+        },
+        {
+            "asset_type": "erc20",
             "name": "weETH",
             "decimals": 18,
             "erc20_contract_address": "0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee",


### PR DESCRIPTION
Add on Ethereum (chainid:1)

EURC
stETH
wstETH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change; main risk is incorrect token metadata (addresses/decimals/symbols) causing mislabeling in consumers.
> 
> **Overview**
> Adds three new Ethereum mainnet (`chainid:1`) ERC-20 entries to `chains/1/assetlist.json`: **Lido Staked Ether (`stETH`)**, **Wrapped stETH (`wstETH`)**, and **Euro Coin (`EURC`)**, including contract addresses, decimals, Coingecko IDs, and logo URIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bddd05e028bad8c7e790ea03df9e0c16dfb78b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->