### PR TITLE
Add cosmoshub-4 support for Eureka EURC

### DIFF
--- a/chains/cosmoshub-4/assetlist.json
+++ b/chains/cosmoshub-4/assetlist.json
@@ -24,6 +24,16 @@
         },
         {
             "asset_type": "cosmos",
+            "name": "Euro Coin",
+            "decimals": 6,
+            "symbol": "EURC",
+            "denom": "ibc/5512EB544A275E5375CE4D82233BDAA2D03002E352A9C6B0049175BD368DF10E",
+            "logo_uri": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c/logo.png",
+            "coingecko_id": "euro-coin",
+            "recommended_symbol": "EURC"
+        },
+        {
+            "asset_type": "cosmos",
             "name": "TON.orai",
             "symbol": "TON.orai",
             "denom": "ibc/FFE1572627ECF442D6E2CA653000FACBA33824732012BCE63DFC25F1E813E5B3",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk metadata-only change that adds a new asset entry; main risk is incorrect denom/logo/coingecko metadata causing display or routing issues for EURC.
> 
> **Overview**
> Adds *Cosmos Hub (`cosmoshub-4`)* support for **Euro Coin (EURC)** by inserting a new asset entry in `chains/cosmoshub-4/assetlist.json` (IBCs denom, decimals, logo URI, and CoinGecko ID) so EURC can be recognized and displayed in consumers of the chain registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53314a6df4343e159865ba576b232b3c4b1f9c0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->