### PR TITLE
Add zigchain-1 support for Ibc EURC

### DIFF
--- a/chains/zigchain-1/assetlist.json
+++ b/chains/zigchain-1/assetlist.json
@@ -8,6 +8,16 @@
             "symbol": "ETH",
             "denom": "ibc/5E970F9FF7B696B42F75B92CC05A74B9C44AB0B5D231FBE794A29D74344B19D7",
             "recommended_symbol": "ETH"
+        },
+        {
+            "asset_type": "cosmos",
+            "name": "Euro Coin",
+            "decimals": 6,
+            "symbol": "EURC",
+            "denom": "ibc/CC5268F89C752A4BDCBDAA574AF0A381786FCC839104E077DA9A9145176BF8ED",
+            "logo_uri": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c/logo.png",
+            "coingecko_id": "euro-coin",
+            "recommended_symbol": "EURC"
         }
     ]
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a new entry to a JSON asset registry with no code-path or security-sensitive logic changes.
> 
> **Overview**
> Adds *IBC EURC* support to `chains/zigchain-1/assetlist.json` by registering the Euro Coin asset (denom, decimals, logo URI, and CoinGecko ID) alongside the existing ETH entry, and fixes the missing trailing newline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef6c7bf0bb2153a20b7d07647dec8b397e46f9b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->