### PR TITLE
feat: add dungeon-1 chain to Skip registry

### DIFF
--- a/chains/dungeon-1/assetlist.json
+++ b/chains/dungeon-1/assetlist.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "../../assetlist.schema.json",
+  "chain_name": "dungeon",
+  "assets": [
+    {
+      "asset_type": "cosmos",
+      "name": "Dragon Coin",
+      "decimals": 6,
+      "symbol": "DGN",
+      "denom": "udgn",
+      "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dungeon/images/DGN.png",
+      "coingecko_id": "dragon-coin-2",
+      "recommended_symbol": "DGN"
+    },
+    {
+      "asset_type": "cosmos",
+      "name": "USD Coin",
+      "decimals": 6,
+      "symbol": "USDC",
+      "denom": "ibc/489C406A3029B50486F991E468CB8A7D5F039757327A40B0684C530BFF96C543",
+      "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.png",
+      "coingecko_id": "usd-coin",
+      "recommended_symbol": "USDC"
+    },
+    {
+      "asset_type": "cosmos",
+      "name": "Cosmos Hub Atom",
+      "decimals": 6,
+      "symbol": "ATOM",
+      "denom": "ibc/C3988DBA4BA195F3514EA2E02497B9F66019CE53EFB96D4982CE95CA6A51BBCE",
+      "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.png",
+      "coingecko_id": "cosmos",
+      "recommended_symbol": "ATOM"
+    },
+    {
+      "asset_type": "cosmos",
+      "name": "Osmosis",
+      "decimals": 6,
+      "symbol": "OSMO",
+      "denom": "ibc/AC72F1D0BF72A358CD9D7E3AC8F868F96EDA9042DE00A72DB4AEA859065B7EB5",
+      "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
+      "coingecko_id": "osmosis",
+      "recommended_symbol": "OSMO"
+    },
+    {
+      "asset_type": "cosmos",
+      "name": "Atone",
+      "decimals": 6,
+      "symbol": "ATONE",
+      "denom": "ibc/295196BD505E32B9679BA0CFDB70B4FF2AADE80A3B73A2F234284D7A709844DA",
+      "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/atomone/images/atomone.png",
+      "coingecko_id": "atomone",
+      "recommended_symbol": "ATONE"
+    },
+    {
+      "asset_type": "cosmos",
+      "name": "Photon",
+      "decimals": 6,
+      "symbol": "PHOTON",
+      "denom": "ibc/BD2C670DB4465BCB862F988EF4FD7595C56AE2ECB9CC9EF14AF7A776091E88AE",
+      "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/atomone/images/photon.png",
+      "coingecko_id": "photon-2",
+      "recommended_symbol": "PHOTON"
+    }
+  ]
+}

--- a/chains/dungeon-1/chain.json
+++ b/chains/dungeon-1/chain.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../../chain.schema.json",
+  "chain_id": "dungeon-1",
+  "is_testnet": false,
+  "chain_name": "dungeon",
+  "chain_type": "cosmos",
+  "pretty_name": "dungeon",
+  "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dungeon/images/DGN.png"
+}


### PR DESCRIPTION
# feat: add dungeon-1 chain to Skip Go registry

## Summary

Adds **dungeon-1** (Dungeon Chain — Cosmos SDK v0.50, native token `$DGN` / `udgn`) to the Skip Go registry so Skip Go Router can route swaps and IBC transfers in and out of the chain.

- `chains/dungeon-1/chain.json` — chain identifier + metadata
- `chains/dungeon-1/assetlist.json` — DGN (native) plus the five IBC assets with established channels and liquidity on dungeon-1: USDC (from Noble), ATOM (from Cosmos Hub), OSMO (from Osmosis), ATONE + PHOTON (from AtomOne)

## Chain background

- **chain_id:** `dungeon-1`
- **bech32 prefix:** `dungeon`
- **slip44:** `118`
- **Native fee/staking denom:** `udgn` (6 decimals, display `DGN`, symbol `DGN`)
- **Stack:** Cosmos SDK v0.50, CosmWasm
- **Live since:** mainnet genesis 2024; currently on chain upgrade `v6` (block ~15.2M), `v7` in voting
- **Operator:** Crypto Dungeon LLC (Dubuque, IA)
- **Existing cosmos/chain-registry entry:** [`dungeon/chain.json`](https://github.com/cosmos/chain-registry/blob/master/dungeon/chain.json) — already merged, satisfies Skip's "metadata available in a commonly used chain registry" requirement.

## Public endpoints

Confirmed live (also listed in cosmos/chain-registry):
- RPC: `https://rpc.dungeongames.io` (official), plus Quasar, Seraphim, ChainTools, WhenMoonWhenLambo
- REST/LCD: `https://api.dungeongames.io` (official), plus Quasar, Seraphim, ChainTools, Apeiron (archive)
- gRPC: `dungeon.grpc.quasarstaking.ai:80`, `grpc.dungeon.chaintools.tech:443`

## IBC channels (already established, see `cosmos/chain-registry/_IBC/`)

| Counterparty | dungeon-1 channel | Counterparty channel | Status |
|---|---|---|---|
| cosmoshub-4 | channel-5308 | channel-1560 | active |
| noble-1 | channel-5307 | channel-150 | active |
| osmosis-1 | channel-5305 | channel-101249 | active |
| neutron-1 | (see `dungeon-neutron.json`) | — | active |
| atomone-1 | channel-5310 | channel-9 | active |
| migaloo-1 / stride / terra2 | various | various | active |

Each counterparty has **a single transfer channel**, consistent with Skip's "only 1 transfer channel per remote chain" rule.

## DEX liquidity (warm-start ready)

dungeon-1 runs a White Whale AMM deployment ("Dungeon DEX") with 12 live pairs. The primary route for Skip would be:

- **DGN ↔ USDC** pool contract: `dungeon1t5p767s5f5y3zjjdxjatz7xjevvc0k8raqygnx4ftqqlnf0ak4dqny33d3`
- Frontend: https://dex.dungeongames.io
- Live TVL (2026-05-22): ~$45.7K on dungeon-1 (D1 DGN-USDC, D1 DGN-ATOM, etc.) — see explorer.dungeongames.io/pools

Tokens are already bridged in (USDC warm-started via Noble channel-5307) — this satisfies Skip's "transfer actual tokens and leave them on destination chains" warm-start requirement.

## Motivation

Skip Go integration unblocks the **Dungeon MetaMask Snap** (https://github.com/Ninjaxan/dungeon-snap) "Spend my DGN" flow: `DGN → USDC on Dungeon DEX → IBC to Noble (channel-5307) → CCTP to Linea → MetaMask Card`. The Noble + CCTP path is preferred over Axelar GMP because (a) the dungeon-1 ↔ noble channel already exists, (b) USDC on dungeon-1 is already canonical Noble USDC, and (c) Circle's CCTP natively supports Linea.

Without dungeon-1 in Skip's registry, MetaMask users holding DGN have no first-class on-ramp to the broader Cosmos and EVM ecosystem.

## Checklist

- [x] cosmos/chain-registry entry exists ([`dungeon/chain.json`](https://github.com/cosmos/chain-registry/blob/master/dungeon/chain.json))
- [x] Single ICS-20 transfer channel per remote chain (verified against `_IBC/dungeon-*.json`)
- [x] Public RPC, REST, gRPC endpoints (5+ providers)
- [x] Warm-start liquidity exists on dungeon-1 (Dungeon DEX, ~$45K TVL)
- [x] CoinGecko ID for `$DGN`: `dragon-coin-2`
- [x] Native fee token (`udgn`) configured with documented gas prices (low 0.05, avg 0.07, high 0.09)
- [x] Logo URI hosted in cosmos/chain-registry under `dungeon/images/DGN.png`

## Open items / questions for the Skip team

1. **`go_fast_enabled`** — left off. Dungeon Chain is not currently part of any Go Fast network; happy to enable if Skip wants this. Please advise on the `go_fast_domain` value to use if so.
2. **Relayer coverage** — Current dungeon-1 ↔ Noble / Cosmos Hub / Osmosis channels are relayed by Quasar, Inter Blockchain Services, and other ecosystem relayers. Happy to provide direct contacts.

## Contact

- Operator: Dr. Lee (Crypto Dungeon LLC) — [@Ninjaxan](https://github.com/Ninjaxan)
- Email: drleeberman@gmail.com
- Discord: available on request
