### PR TITLE
Add Axiome (axiome-1)

### DIFF
--- a/chains/axiome-1/assetlist.json
+++ b/chains/axiome-1/assetlist.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "../../assetlist.schema.json",
+    "chain_name": "axiome",
+    "assets": [
+        {
+            "asset_type": "cosmos",
+            "name": "Axiome",
+            "decimals": 6,
+            "symbol": "AXM",
+            "denom": "uaxm",
+            "logo_uri": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/axiome/uaxm.png",
+            "coingecko_id": "axiome"
+        },
+        {
+            "asset_type": "cosmos",
+            "name": "RIP",
+            "decimals": 6,
+            "symbol": "RIP",
+            "denom": "cw20:axm1sj7zrll8n6rh07hgzqtjemeeane53a68fzqzsmnyntw95w4h7z6s24683a",
+            "coingecko_id": "rip"
+        },
+        {
+            "asset_type": "cosmos",
+            "name": "Collexium",
+            "decimals": 6,
+            "symbol": "CLX",
+            "denom": "cw20:axm1hfaf96lt2y2dx2cr04svej0s0srqydhncxga5lh6zlrzw77d8qzqxday46"
+        }
+    ]
+}

--- a/chains/axiome-1/assetlist.json
+++ b/chains/axiome-1/assetlist.json
@@ -13,10 +13,19 @@
         },
         {
             "asset_type": "cosmos",
+            "name": "Referral Energy Token",
+            "decimals": 6,
+            "symbol": "RET",
+            "denom": "uret",
+            "logo_uri": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/axiome/uret.png"
+        },
+        {
+            "asset_type": "cosmos",
             "name": "RIP",
             "decimals": 6,
             "symbol": "RIP",
             "denom": "cw20:axm1sj7zrll8n6rh07hgzqtjemeeane53a68fzqzsmnyntw95w4h7z6s24683a",
+            "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axiome/images/rip.png",
             "coingecko_id": "rip"
         },
         {
@@ -24,7 +33,8 @@
             "name": "Collexium",
             "decimals": 6,
             "symbol": "CLX",
-            "denom": "cw20:axm1hfaf96lt2y2dx2cr04svej0s0srqydhncxga5lh6zlrzw77d8qzqxday46"
+            "denom": "cw20:axm1hfaf96lt2y2dx2cr04svej0s0srqydhncxga5lh6zlrzw77d8qzqxday46",
+            "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axiome/images/clx.png"
         }
     ]
 }

--- a/chains/axiome-1/chain.json
+++ b/chains/axiome-1/chain.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "../../chain.schema.json",
+    "chain_id": "axiome-1",
+    "is_testnet": false,
+    "chain_name": "axiome",
+    "pretty_name": "Axiome",
+    "chain_type": "cosmos",
+    "logo_uri": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/axiome/chain.png",
+    "apis": {
+        "tendermint_rpc_endpoint": {
+            "address": "https://api-chain.axiomechain.org",
+            "provider": "Axiome"
+        },
+        "lcd_rest_endpoint": {
+            "address": "https://axm-lcd.trickle.pro",
+            "provider": "Trickle"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds **Axiome** (`axiome-1`) to the registry: a Cosmos SDK 0.50 + CosmWasm (wasmd 0.50) chain with a live wasmswap DEX (43 pools, all sharing one code id).

The Skip Go contracts are **already deployed and exercised** on this chain:

| | address |
|---|---|
| entry point | `axm13vwgdq5anzwysrxupljws9fq6w5qgjl4c8wr4n57v5pdl38j996sewd4sw` |
| wasmswap adapter | `axm1ncs9pxgz5fmplhy5els7ctvhranp3h4eknxgh829786fnqh8sats8ral79` |
| venue name | `axiome-wasmswap` |

The adapter itself is submitted separately in skip-mev/skip-go-cosmwasm-contracts#172. Both swap directions were executed end to end against the live RIP/AXM pool and matched the simulation exactly.

## Endpoints

- RPC `https://api-chain.axiomechain.org` (HTTPS, CORS enabled, WebSocket available)
- REST `https://axm-lcd.trickle.pro` (HTTPS, CORS enabled, cached, with failover to a second upstream node and uptime monitoring)

Both are already used as the official endpoints for Axiome in the Keplr chain registry (chainapsis/keplr-chain-registry#1538, merged).

## Assets

AXM (native, on CoinGecko as `axiome`), RET, and the two cw20 tokens with the deepest liquidity, RIP (CoinGecko `rip`) and CLX. All four carry a `logo_uri`.

RET is the chain's second native denom. It is minted to the referral upline when a delegation is made, and it trades against AXM on the same AMM, so it belongs in the list. It is not on CoinGecko, so it carries no `coingecko_id`.

## Scope

Axiome has no IBC module, so this entry covers **same chain swaps only** (the routing case your API already supports, as an intra chain route resolves to a single swap operation). No IBC path, bridge or transfer adapter is claimed here.

